### PR TITLE
fix link to direct download link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Bintray:
 
 https://bintray.com/pkg/show/general/jprante/elasticsearch-plugins/elasticsearch-knapsack
 
-`Direct download <http://dl.bintray.com/content/jprante/elasticsearch-plugins/org/xbib/elasticsearch/elasticsearch-knapsack/2.0.0/elasticsearch-knapsack-2.0.0.zip>`_
+`Direct download <http://dl.bintray.com/jprante/elasticsearch-plugins/org/xbib/elasticsearch/plugin/elasticsearch-knapsack/2.0.0/elasticsearch-knapsack-2.0.0.zip?direct>`_
 
 Command::
 


### PR DESCRIPTION
The direct download link wasn't working properly (gave a Path 'jprante/elasticsearch-plugins/org/xbib/elasticsearch/elasticsearch-knapsack/2.0.0/elasticsearch-knapsack-2.0.0.zip' was not found. errror), so I have fixed it.
