### PR TITLE
Fix for Issue #17. 

### DIFF
--- a/src/main/java/org/xbib/io/commons/TarSession.java
+++ b/src/main/java/org/xbib/io/commons/TarSession.java
@@ -55,7 +55,7 @@ public class TarSession implements Session {
         switch (mode) {
             case READ:
                 if (scheme.startsWith("targz")) {
-                    String s = part + ".tar.gz";
+                    String s = (part.endsWith("tar.gz")) ? part : part + ".tar.gz";
                     File f = new File(s);
                     if (f.isFile() && f.canRead()) {
                         this.fin = new FileInputStream(f);
@@ -65,7 +65,7 @@ public class TarSession implements Session {
                         throw new FileNotFoundException("check existence or access rights: " + s);
                     }
                 } else if (scheme.startsWith("tarbz2")) {
-                    String s = part + ".tar.bz2";
+                    String s = (part.endsWith("tar.bz2")) ? part : part + ".tar.bz2";
                     File f = new File(s);
                     if (f.isFile() && f.canRead()) {
                         this.fin = new FileInputStream(f);
@@ -75,7 +75,7 @@ public class TarSession implements Session {
                         throw new FileNotFoundException("check existence or access rights: " + s);
                     }
                 } else if (scheme.startsWith("tarxz")) {
-                    String s = part + ".tar.xz";
+                    String s = (part.endsWith(".tar.xz")) ? part : part + ".tar.xz";
                     File f = new File(s);
                     if (f.isFile() && f.canRead()) {
                         this.fin = new FileInputStream(f);
@@ -85,7 +85,7 @@ public class TarSession implements Session {
                         throw new FileNotFoundException("check existence or access rights: " + s);
                     }
                 } else {
-                    String s = part + ".tar";
+                    String s = (part.endsWith(".tar")) ? part : part + ".tar";
                     File f = new File(s);
                     if (f.isFile() && f.canRead()) {
                         this.fin = new FileInputStream(f);


### PR DESCRIPTION
Hello,

This is a fix for issue #17 at which the import target parameter fails when a file extension is provided. 
I just check if the file extension is provided and if it does then the appending is omitted.

Index imports now work in both cases:

```
curl -XPOST 'localhost:9200/testing/_import?target=/tmp/testing'
```

and

```
curl -XPOST 'localhost:9200/testing/_import?target=/tmp/testing.tar.gz'
```
