### PR TITLE
Added support for backups/restores using S3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.6.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -14,6 +14,10 @@
             <includes>
                 <include>org.xbib.elasticsearch.plugin</include>
                 <include>org.apache.commons:*</include>
+                <include>*aws*</include>
+                <include>*commons*</include>
+                <include>*jackson*</include>
+                <include>*http*</include>
             </includes>
         </dependencySet>
     </dependencySets>  

--- a/src/main/java/org/xbib/elasticsearch/s3/S3.java
+++ b/src/main/java/org/xbib/elasticsearch/s3/S3.java
@@ -1,0 +1,20 @@
+package org.xbib.elasticsearch.s3;
+
+import java.io.IOException;
+
+public interface S3 {
+    /**
+     * Transfer a local file to S3
+     * @param bucket S3 bucket name
+     * @param s3Path The path inside the S3 bucket where the file should be saved
+     */
+    public void writeToS3(String bucket, String s3path);
+
+    /**
+     * Save an artifact from S3 to the local disk
+     * @param bucket S3 bucket name
+     * @param s3Path The path inside the S3 bucket from where the file should be downloaded
+     * @throws IOException An IOException is thrown when is unable to write to the target
+     */
+    public void readFromS3(String bucket, String s3path) throws IOException;
+}

--- a/src/main/java/org/xbib/elasticsearch/s3/S3Factory.java
+++ b/src/main/java/org/xbib/elasticsearch/s3/S3Factory.java
@@ -1,0 +1,14 @@
+package org.xbib.elasticsearch.s3;
+
+public interface S3Factory {
+
+    /**
+     * Returns the s3client
+     * @param target archive location
+     * @param accessKeyId aws access key id parameter
+     * @param secretAccessKey aws secret access key parameter
+     * @return
+     */
+    S3 getS3(String target, String accessKeyId, String secretAccessKey);
+
+}

--- a/src/main/java/org/xbib/elasticsearch/s3/S3FactoryImpl.java
+++ b/src/main/java/org/xbib/elasticsearch/s3/S3FactoryImpl.java
@@ -1,0 +1,12 @@
+
+package org.xbib.elasticsearch.s3;
+
+public final class S3FactoryImpl implements S3Factory {
+
+    @Override
+    public S3 getS3(String target, String accessKeyId, String secretAccessKey) {
+        S3 s3 = new S3Impl(target, accessKeyId, secretAccessKey);
+        return s3;
+    }
+
+}

--- a/src/main/java/org/xbib/elasticsearch/s3/S3Impl.java
+++ b/src/main/java/org/xbib/elasticsearch/s3/S3Impl.java
@@ -1,0 +1,72 @@
+package org.xbib.elasticsearch.s3;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+
+public class S3Impl implements S3 {
+
+    private final AmazonS3 s3client;
+
+    private final String archivePath;
+
+    public S3Impl(String target, String accessKeyId, String secretAccessKey) {
+        if(accessKeyId != null && secretAccessKey != null){
+            this.s3client = new AmazonS3Client(new BasicAWSCredentials(accessKeyId, secretAccessKey));
+        } else {
+            this.s3client = new AmazonS3Client(new DefaultAWSCredentialsProviderChain());
+        }
+
+        this.archivePath = getArchivePath(target);
+    }
+
+    private String getArchivePath(String target) {
+        if (!(target.endsWith("tar.gz") || target.endsWith("tar.bz2") || target.endsWith(".tar.xz") || target
+                .endsWith(".tar"))) {
+            target += ".tar.gz";
+        }
+        return target;
+    }
+
+    @Override
+    public void writeToS3(String s3bucket, String s3Path) {
+        File file = new File(archivePath);
+        s3client.putObject(new PutObjectRequest(s3bucket, s3Path, file));
+        file.delete();
+    }
+
+    @Override
+    public void readFromS3(String s3bucket, String s3Path) throws IOException {
+       S3Object object = s3client.getObject(new GetObjectRequest(s3bucket, s3Path));
+       saveS3ObjectToDisk(object, archivePath);
+    }
+
+    private void saveS3ObjectToDisk(S3Object object, String filePath) throws IOException{
+        InputStream reader = new BufferedInputStream(object.getObjectContent());
+        File file = new File(filePath);
+
+        OutputStream writer = new BufferedOutputStream(new FileOutputStream(file));
+
+        int read = -1;
+        while ((read = reader.read()) != -1) {
+            writer.write(read);
+        }
+
+        writer.flush();
+        writer.close();
+        reader.close();
+    }
+
+}

--- a/src/main/java/org/xbib/elasticsearch/s3/S3Service.java
+++ b/src/main/java/org/xbib/elasticsearch/s3/S3Service.java
@@ -1,0 +1,27 @@
+
+package org.xbib.elasticsearch.s3;
+
+import java.util.Iterator;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+public class S3Service {
+
+    private final static S3Service instance = new S3Service();
+
+    public static S3Service getInstance() {
+        return instance;
+    }
+
+    public S3Factory getS3Factory(){
+        S3Factory s3Factory;
+        ServiceLoader<S3Factory> loader = ServiceLoader.load(S3Factory.class);
+        Iterator<S3Factory> it = loader.iterator();
+        while (it.hasNext()) {
+            s3Factory = it.next();
+            return s3Factory;
+        }
+        throw new ServiceConfigurationError("no suitable implementation found");
+    }
+
+}

--- a/src/main/resources/META-INF/services/org.xbib.elasticsearch.s3.S3Factory
+++ b/src/main/resources/META-INF/services/org.xbib.elasticsearch.s3.S3Factory
@@ -1,0 +1,1 @@
+org.xbib.elasticsearch.s3.S3FactoryImpl


### PR DESCRIPTION
This is related to Issue #29 and takes into account the implementation details mentioned there. 

**Usage**

_Export_

```
curl -XPOST 'localhost:9200/test_index/_export/s3?target=/tmp/test_index.tar.gz&s3path=/path/in/bucket/test_index.tar.gz&s3bucket=bucketname&accesskey=XXXX&secretkey=XXXX'
```

_Import_

```
curl -XPOST 'localhost:9200/test_index/_import/s3?target=/tmp/test_index.tar.gz&s3path=/path/in/bucket/test_index.tar.gz&s3bucket=bucketname&accesskey=XXXX&secretkey=XXXX'
```

**Details**
- If the aws credentials are not provided in the request then the DefaultAWSCredentialsProviderChain is used. (this effectively means that the credentials are automatically delivered through the Amazon EC2 metadata service when knapsack is running on an EC2 instance)
- On a successful upload the locally exported archive gets deleted. 
- plugin.xml adds all the required dependencies but this could be refactored to have multiple assemblies 
