### PR TITLE
Update to Elasticsearch 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ When importing archive files again, this information is reapplied.
 
 | Elasticsearch  |   Plugin       | Release date |
 | -------------- | -------------- | ------------ |
+| 2.4.0          | 2.4.0.0        | Aug  31, 2016|
 | 2.3.4          | 2.3.4.0        | Aug  4, 2016 |
 | 2.3.3          | 2.3.3.0        | May 23, 2016 |
 | 2.3.1          | 2.3.1.0        | Apr 21, 2016 |
@@ -43,7 +44,7 @@ For older releases and 1.x versions, see the repective branches.
 
 ## Installation 2.x
 
-    ./bin/plugin install http://xbib.org/repository/org/xbib/elasticsearch/plugin/elasticsearch-knapsack/2.3.4.0/elasticsearch-knapsack-2.3.4.0-plugin.zip
+    ./bin/plugin install http://xbib.org/repository/org/xbib/elasticsearch/plugin/elasticsearch-knapsack/2.4.0.0/elasticsearch-knapsack-2.4.0.0-plugin.zip
 
 Do not forget to restart the node after installation.
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
     scmConnection = 'scm:git:git://github.com/' + user + '/' + name + '.git'
     scmDeveloperConnection = 'scm:git:git://github.com/' + user + '/' + name + '.git'
     versions = [
-        'elasticsearch' : '2.3.4',
+        'elasticsearch' : '2.4.0',
         'elasticsearch-helper' : '2.3.4.0',
         'log4j': '2.5',
         'junit' : '4.12',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.xbib.elasticsearch.plugin
-version = 2.3.4.0
+version = 2.4.0.0
 org.gradle.daemon = true


### PR DESCRIPTION
Upgraded to support elasticsearch 2.4.0, released on 31st August.

https://github.com/jprante/elasticsearch-helper/pull/8 would need to be merged, and its dependency version in the `build.gradle` in this repository updated before this can go in.

Hope this helps! 
